### PR TITLE
Fix trailing dashes

### DIFF
--- a/src/generate-branch-alias.ts
+++ b/src/generate-branch-alias.ts
@@ -9,9 +9,7 @@ const maxAliasLength = 28
 const alphanum = 'abcdefghijklmnopqrstuvwxyz0123456789'
 
 export function generateBranchAlias(branch: string): string {
-  let normalised = branch.toLowerCase().replace(invalidCharsRegex, '-'),
-    '-'
-  )
+  let normalised = branch.toLowerCase().replace(invalidCharsRegex, '-')
 
   if (normalised.length > maxAliasLength) {
     normalised = normalised.substring(0, maxAliasLength)

--- a/src/generate-branch-alias.ts
+++ b/src/generate-branch-alias.ts
@@ -9,19 +9,20 @@ const maxAliasLength = 28
 const alphanum = 'abcdefghijklmnopqrstuvwxyz0123456789'
 
 export function generateBranchAlias(branch: string): string {
-  const normalised = trim(
-    branch.toLowerCase().replace(invalidCharsRegex, '-'),
+  let normalised = branch.toLowerCase().replace(invalidCharsRegex, '-'),
     '-'
   )
+
+  if (normalised.length > maxAliasLength) {
+    normalised = normalised.substring(0, maxAliasLength)
+  }
+
+  normalised = trim(normalised, '-')
 
   if (normalised === '') {
     return `branch-${randAlphaNum(10)}`
   }
-
-  if (normalised.length > maxAliasLength) {
-    return normalised.substring(0, maxAliasLength)
-  }
-
+  
   return normalised
 }
 


### PR DESCRIPTION
Fix an issue where trailing dashes would not be trimmed if the dashes appear at character 28 and there are non-dash characters after them.

For example: `aaaaaaaaaaaaaaaaaaaaaaaaaaa-bbb` would lead to the branch alias being `aaaaaaaaaaaaaaaaaaaaaaaaaaa-` instead of `aaaaaaaaaaaaaaaaaaaaaaaaaaa`.

Closes: https://github.com/schnerring/cloudflare-pages-branch-alias-action/issues/165